### PR TITLE
Add composer template

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -13,6 +13,7 @@
         "docs": "https://docs.zendframework.com/<project-name>/",
         "issues": "https://github.com/zendframework/<project-name>/issues",
         "source": "https://github.com/zendframework/<project-name>",
+        "rss": "https://github.com/zendframework/<project-name>/releases.atom",
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/<components|expressive|apigility>"
     },

--- a/template/composer.json
+++ b/template/composer.json
@@ -33,6 +33,9 @@
             "ZendTest\\<project-name>\\": "test/"
         }
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev",

--- a/template/composer.json
+++ b/template/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.6 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2 || ^5.7",
+        "phpunit/phpunit": "^5.7 || ^6.2",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {

--- a/template/composer.json
+++ b/template/composer.json
@@ -1,10 +1,12 @@
 {
     "name": "zendframework/<project-name>",
-    "description": "<project-description>",
+    "description": "<project description, the same like the repository description>",
     "homepage": "https://docs.zendframework.com/<project-name>/",
     "type": "library",
     "license": "BSD-3-Clause",
     "keywords": [
+        "zend",
+        "zendframework",
         "<individual keywords for current project>"
     ],
     "support": {
@@ -12,7 +14,7 @@
         "issues": "https://github.com/zendframework/<project-name>/issues",
         "source": "https://github.com/zendframework/<project-name>",
         "slack": "https://zendframework-slack.herokuapp.com",
-        "forum": "https://discourse.zendframework.com"
+        "forum": "https://discourse.zendframework.com/c/questions/<components|expressive|apigility>"
     },
     "extra": {
         "branch-alias": {
@@ -21,10 +23,10 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.0 || ^5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+        "phpunit/phpunit": "^6.2.3 || ^5.7.21",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {

--- a/template/composer.json
+++ b/template/composer.json
@@ -1,18 +1,19 @@
 {
-    "name": "zendframework/<project-name>",
-    "description": "<project description, the same like the repository description>",
-    "homepage": "https://docs.zendframework.com/<project-name>/",
+    "name": "zendframework/<package_name>",
+    "description": "<package_description, the same like the repository description>",
+    "homepage": "https://docs.zendframework.com/<package_name>/",
     "license": "BSD-3-Clause",
     "keywords": [
         "zend",
         "zendframework",
-        "<individual keywords for current project>"
+        "<package_name>",
+        "<individual keywords for current package>"
     ],
     "support": {
-        "docs": "https://docs.zendframework.com/<project-name>/",
-        "issues": "https://github.com/zendframework/<project-name>/issues",
-        "source": "https://github.com/zendframework/<project-name>",
-        "rss": "https://github.com/zendframework/<project-name>/releases.atom",
+        "docs": "https://docs.zendframework.com/<package_name>/",
+        "issues": "https://github.com/zendframework/<package_name>/issues",
+        "source": "https://github.com/zendframework/<package_name>",
+        "rss": "https://github.com/zendframework/<package_name>/releases.atom",
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/<components|expressive|apigility>"
     },
@@ -25,12 +26,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Zend\\<project-name>\\": "src/"
+            "Zend\\<package_name>\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "ZendTest\\<project-name>\\": "test/"
+            "ZendTest\\<package_name>\\": "test/"
         }
     },
     "config": {

--- a/template/composer.json
+++ b/template/composer.json
@@ -16,12 +16,6 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/<components|expressive|apigility>"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0-dev",
-            "dev-develop": "1.1-dev"
-        }
-    },
     "require": {
         "php": "^5.6 || ^7.0"
     },
@@ -37,6 +31,12 @@
     "autoload-dev": {
         "psr-4": {
             "ZendTest\\<project-name>\\": "test/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev",
+            "dev-develop": "1.1-dev"
         }
     },
     "scripts": {

--- a/template/composer.json
+++ b/template/composer.json
@@ -2,7 +2,6 @@
     "name": "zendframework/<project-name>",
     "description": "<project description, the same like the repository description>",
     "homepage": "https://docs.zendframework.com/<project-name>/",
-    "type": "library",
     "license": "BSD-3-Clause",
     "keywords": [
         "zend",

--- a/template/composer.json
+++ b/template/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
+        "phpunit/phpunit": "^6.3",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {

--- a/template/composer.json
+++ b/template/composer.json
@@ -1,0 +1,55 @@
+{
+    "name": "zendframework/<project-name>",
+    "description": "<project-description>",
+    "homepage": "https://docs.zendframework.com/<project-name>/",
+    "type": "library",
+    "license": "BSD-3-Clause",
+    "keywords": [
+        "http",
+        "middleware",
+        "psr",
+        "psr-7",
+        "psr-11"
+    ],
+    "support": {
+        "docs": "https://docs.zendframework.com/<project-name>/",
+        "issues": "https://github.com/zendframework/<project-name>/issues",
+        "source": "https://github.com/zendframework/<project-name>",
+        "slack": "https://zendframework-slack.herokuapp.com",
+        "forum": "https://discourse.zendframework.com"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev",
+            "dev-develop": "2.0-dev"
+        }
+    },
+    "require": {
+        "php": "^5.6 || ^7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+        "zendframework/zend-coding-standard": "~1.0.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Zend\\<project-name>\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ZendTest\\<project-name>\\": "test/"
+        }
+    },
+    "scripts": {
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "upload-coverage": "coveralls -v",
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
+        "test": "phpunit --colors=always",
+        "test-coverage": "phpunit --coverage-clover clover.xml"
+    }
+}

--- a/template/composer.json
+++ b/template/composer.json
@@ -5,11 +5,7 @@
     "type": "library",
     "license": "BSD-3-Clause",
     "keywords": [
-        "http",
-        "middleware",
-        "psr",
-        "psr-7",
-        "psr-11"
+        "<individual keywords for current project>"
     ],
     "support": {
         "docs": "https://docs.zendframework.com/<project-name>/",

--- a/template/composer.json
+++ b/template/composer.json
@@ -19,14 +19,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev",
-            "dev-develop": "2.0-dev"
+            "dev-develop": "1.1-dev"
         }
     },
     "require": {
-        "php": "^7.0 || ^5.6"
+        "php": "^5.6 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2.3 || ^5.7.21",
+        "phpunit/phpunit": "^6.2 || ^5.7",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {
@@ -44,10 +44,10 @@
             "@cs-check",
             "@test"
         ],
-        "upload-coverage": "coveralls -v",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --coverage-clover clover.xml"
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
+        "upload-coverage": "coveralls -v"
     }
 }

--- a/template/composer.json
+++ b/template/composer.json
@@ -18,10 +18,10 @@
         "forum": "https://discourse.zendframework.com/c/questions/<components|expressive|apigility>"
     },
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.2",
+        "phpunit/phpunit": "^6.2",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {


### PR DESCRIPTION
As discussed in several communication channels, there is no clear path on how the composer.json file should look like these days. There have been many changes which were not communicated to all maintainers and contributors in a central place. This PR adds a composer.json template to provide that central communication to everyone involved.