### PR TITLE
Added section "Changed" into changelog

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -183,6 +183,10 @@ we follow [Keep a CHANGELOG](http://keepachangelog.com/). The format is simple:
 
 - [#42](https://github.com/organization/project/pull/42) adds documentation!
 
+### Changed
+
+- Nothing.
+
 ### Deprecated
 
 - Nothing.
@@ -359,6 +363,11 @@ Added
 
 - [#42](https://github.com/organization/project/pull/42) adds documentation!
 
+Changed
+-------
+
+- Nothing.
+
 Deprecated
 ----------
 
@@ -532,6 +541,10 @@ version represented by the `master` branch:
 
 - Nothing.
 
+### Changed
+
+- Nothing.
+
 ### Deprecated
 
 - Nothing.
@@ -547,6 +560,10 @@ version represented by the `master` branch:
 ## 2.5.3 - TBD
 
 ### Added
+
+- Nothing.
+
+### Changed
 
 - Nothing.
 
@@ -589,6 +606,10 @@ branch's changelog. As an example, consider the following:
 
 - Useful features that everyone will want.
 
+### Changed
+
+- Nothing.
+
 ### Deprecated
 
 - Useless features that are no longer needed.
@@ -604,6 +625,10 @@ branch's changelog. As an example, consider the following:
 ## 2.5.3 - TBD
 
 ### Added
+
+- Nothing.
+
+### Changed
 
 - Nothing.
 
@@ -628,6 +653,10 @@ The above would be merged to a single changelog entry for 2.6.0 which would look
 ### Added
 
 - Useful features that everyone will want.
+
+### Changed
+
+- Nothing.
 
 ### Deprecated
 

--- a/src/ChangelogBump.php
+++ b/src/ChangelogBump.php
@@ -110,6 +110,7 @@ class ChangelogBump
 
         $changelog = sprintf("\n\n## %s - TBD\n\n", $version)
             . "### Added\n\n- Nothing.\n\n"
+            . "### Changed\n\n- Nothing.\n\n"
             . "### Deprecated\n\n- Nothing.\n\n"
             . "### Removed\n\n- Nothing.\n\n"
             . "### Fixed\n\n- Nothing.\n\n";


### PR DESCRIPTION
Section "changed" was missing in our documentation. It is specified in http://keepachangelog.com/en/1.0.0/ and already used with some releases:
https://github.com/zendframework/zend-expressive/releases/tag/2.0.3
https://github.com/zendframework/zend-expressive-skeleton/releases/tag/2.0.3
...