### PR TITLE
Adds support file templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ repositories, including:
 - a `docs/` directory with support templates:
   - `CODE_OF_CONDUCT.md` with the Code Manifesto.
   - `CONTRIBUTING.md` with instructions on how to contribute; replace the
-    placeholders `{org}`, `{repo}` with appropriate values.
+    placeholders `{org}` and `{repo}` with appropriate values.
   - `ISSUE_TEMPLATE.md` for new issues; replace the placeholders `{org}` and
     `{repo}` with appropriate values.
   - `PULL_REQUEST_TEMPLATE.md` for new pull requests.
   - `SUPPORT.md` with instructions on how to get support for the package;
-    replace the placeholders `{org}`, `{repo}` with appropriate values.
+    replace the placeholders `{org}` and `{repo}` with appropriate values;
+    replace the placeholder `{category}` with one of `expressive`, `components`,
+    or `apigility`, depending on the repository type.
 
 ## Maintainer tools
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ Framework.
 
 For documentation guidelines, visit the [documentation repository](https://github.com/zendframework/documentation/blob/master/CONTRIBUTING.md).
 
+## Templates
+
+The `template/` directory contains templates for use in creating new
+repositories, including:
+
+- a `LICENSE.md` template; replace `{year}` with the year of creation and/or a
+  range of dates from creation to latest updates.
+- a `.travis.yml` template with recommended configuration for new components.
+- a `docs/` directory with support templates:
+  - `CODE_OF_CONDUCT.md` with the Code Manifesto.
+  - `CONTRIBUTING.md` with instructions on how to contribute; replace the
+    placeholders `{org}`, `{repo}` with appropriate values.
+  - `ISSUE_TEMPLATE.md` for new issues; replace the placeholders `{org}` and
+    `{repo}` with appropriate values.
+  - `PULL_REQUEST_TEMPLATE.md` for new pull requests.
+  - `SUPPORT.md` with instructions on how to get support for the package;
+    replace the placeholders `{org}`, `{repo}` with appropriate values.
+
 ## Maintainer tools
 
 CLI tools for automating several tasks, particularly the LTS workflows, are present in this

--- a/template/LICENSE.md
+++ b/template/LICENSE.md
@@ -1,0 +1,27 @@
+Copyright (c) {year}, Zend Technologies USA, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+- Neither the name of Zend Technologies USA, Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/template/docs/CODE_OF_CONDUCT.md
+++ b/template/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Code of Conduct
+
+This project adheres to [The Code Manifesto](http://codemanifesto.com)
+as its guidelines for contributor interactions.
+
+## The Code Manifesto
+
+We want to work in an ecosystem that empowers developers to reach their
+potential — one that encourages growth and effective collaboration. A space that
+is safe for all.
+
+A space such as this benefits everyone that participates in it. It encourages
+new developers to enter our field. It is through discussion and collaboration
+that we grow, and through growth that we improve.
+
+In the effort to create such a place, we hold to these values:
+
+1. **Discrimination limits us.** This includes discrimination on the basis of
+   race, gender, sexual orientation, gender identity, age, nationality, technology
+   and any other arbitrary exclusion of a group of people.
+2. **Boundaries honor us.** Your comfort levels are not everyone’s comfort
+   levels. Remember that, and if brought to your attention, heed it.
+3. **We are our biggest assets.** None of us were born masters of our trade.
+   Each of us has been helped along the way. Return that favor, when and where
+   you can.
+4. **We are resources for the future.** As an extension of #3, share what you
+   know. Make yourself a resource to help those that come after you.
+5. **Respect defines us.** Treat others as you wish to be treated. Make your
+   discussions, criticisms and debates from a position of respectfulness. Ask
+   yourself, is it true? Is it necessary? Is it constructive? Anything less is
+   unacceptable.
+6. **Reactions require grace.** Angry responses are valid, but abusive language
+   and vindictive actions are toxic. When something happens that offends you,
+   handle it assertively, but be respectful. Escalate reasonably, and try to
+   allow the offender an opportunity to explain themselves, and possibly correct
+   the issue.
+7. **Opinions are just that: opinions.** Each and every one of us, due to our
+   background and upbringing, have varying opinions. The fact of the matter, is
+   that is perfectly acceptable. Remember this: if you respect your own
+   opinions, you should respect the opinions of others.
+8. **To err is human.** You might not intend it, but mistakes do happen and
+   contribute to build experience. Tolerate honest mistakes, and don't hesitate
+   to apologize if you make one yourself.

--- a/template/docs/CONTRIBUTING.md
+++ b/template/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 If you wish to contribute to this project, please be sure to
 read/subscribe to the following resources:
 
- - [Coding Standards](https://github.com/{org}/{repo})
+ - [Coding Standards](https://github.com/zendframework/zend-coding-standard)
  - [Forums](https://discourse.zendframework.com/c/contributors)
  - [Slack](https://zendframework-slack.herokuapp.com)
  - [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/template/docs/CONTRIBUTING.md
+++ b/template/docs/CONTRIBUTING.md
@@ -1,0 +1,189 @@
+# CONTRIBUTING
+
+## RESOURCES
+
+If you wish to contribute to this project, please be sure to
+read/subscribe to the following resources:
+
+ - [Coding Standards](https://github.com/{org}/{repo})
+ - [Forums](https://discourse.zendframework.com/c/contributors)
+ - [Slack](https://zendframework-slack.herokuapp.com)
+ - [Code of Conduct](CODE_OF_CONDUCT.md)
+
+If you are working on new features or refactoring
+[create a proposal](https://github.com/{org}/{repo}/issues/new).
+
+## RUNNING TESTS
+
+To run tests:
+
+- Clone the repository:
+
+  ```console
+  $ git clone git://github.com/{org}/{repo}.git
+  $ cd {repo}
+  ```
+
+- Install dependencies via composer:
+
+  ```console
+  $ composer install
+  ```
+
+  If you don't have `composer` installed, please download it from https://getcomposer.org/download/
+
+- Run the tests using the "test" command shipped in the `composer.json`:
+
+  ```console
+  $ composer test
+  ```
+
+You can turn on conditional tests with the `phpunit.xml` file.
+To do so:
+
+ -  Copy `phpunit.xml.dist` file to `phpunit.xml`
+ -  Edit `phpunit.xml` to enable any specific functionality you
+    want to test, as well as to provide test values to utilize.
+
+## Running Coding Standards Checks
+
+First, ensure you've installed dependencies via composer, per the previous
+section on running tests.
+
+To run CS checks only:
+
+```console
+$ composer cs-check
+```
+
+To attempt to automatically fix common CS issues:
+
+```console
+$ composer cs-fix
+```
+
+If the above fixes any CS issues, please re-run the tests to ensure
+they pass, and make sure you add and commit the changes after verification.
+
+## Recommended Workflow for Contributions
+
+Your first step is to establish a public repository from which we can
+pull your work into the master repository. We recommend using
+[GitHub](https://github.com), as that is where the component is already hosted.
+
+1. Setup a [GitHub account](https://github.com/), if you haven't yet
+2. Fork the repository (https://github.com/{org}/{repo})
+3. Clone the canonical repository locally and enter it.
+
+   ```console
+   $ git clone git://github.com/{org}/{repo}.git
+   $ cd {repo}
+   ```
+
+4. Add a remote to your fork; substitute your GitHub username in the command
+   below.
+
+   ```console
+   $ git remote add {username} git@github.com:{username}/{repo}.git
+   $ git fetch {username}
+   ```
+
+### Keeping Up-to-Date
+
+Periodically, you should update your fork or personal repository to
+match the canonical ZF repository. Assuming you have setup your local repository
+per the instructions above, you can do the following:
+
+
+```console
+$ git checkout master
+$ git fetch origin
+$ git rebase origin/master
+# OPTIONALLY, to keep your remote up-to-date -
+$ git push {username} master:master
+```
+
+If you're tracking other branches -- for example, the "develop" branch, where
+new feature development occurs -- you'll want to do the same operations for that
+branch; simply substitute  "develop" for "master".
+
+### Working on a patch
+
+We recommend you do each new feature or bugfix in a new branch. This simplifies
+the task of code review as well as the task of merging your changes into the
+canonical repository.
+
+A typical workflow will then consist of the following:
+
+1. Create a new local branch based off either your master or develop branch.
+2. Switch to your new local branch. (This step can be combined with the
+   previous step with the use of `git checkout -b`.)
+3. Do some work, commit, repeat as necessary.
+4. Push the local branch to your remote repository.
+5. Send a pull request.
+
+The mechanics of this process are actually quite trivial. Below, we will
+create a branch for fixing an issue in the tracker.
+
+```console
+$ git checkout -b hotfix/9295
+Switched to a new branch 'hotfix/9295'
+```
+
+... do some work ...
+
+
+```console
+$ git commit
+```
+
+... write your log message ...
+
+
+```console
+$ git push {username} hotfix/9295:hotfix/9295
+Counting objects: 38, done.
+Delta compression using up to 2 threads.
+Compression objects: 100% (18/18), done.
+Writing objects: 100% (20/20), 8.19KiB, done.
+Total 20 (delta 12), reused 0 (delta 0)
+To ssh://git@github.com/{username}/{repo}.git
+   b5583aa..4f51698  HEAD -> master
+```
+
+To send a pull request, you have two options.
+
+If using GitHub, you can do the pull request from there. Navigate to
+your repository, select the branch you just created, and then select the
+"Pull Request" button in the upper right. Select the user/organization
+"zendframework" (or whatever the upstream organization is) as the recipient.
+
+#### What branch to issue the pull request against?
+
+Which branch should you issue a pull request against?
+
+- For fixes against the stable release, issue the pull request against the
+  "master" branch.
+- For new features, or fixes that introduce new elements to the public API (such
+  as new public methods or properties), issue the pull request against the
+  "develop" branch.
+
+### Branch Cleanup
+
+As you might imagine, if you are a frequent contributor, you'll start to
+get a ton of branches both locally and on your remote.
+
+Once you know that your changes have been accepted to the master
+repository, we suggest doing some cleanup of these branches.
+
+-  Local branch cleanup
+
+   ```console
+   $ git branch -d <branchname>
+   ```
+
+-  Remote branch removal
+
+   ```console
+   $ git push {username} :<branchname>
+   ```

--- a/template/docs/ISSUE_TEMPLATE.md
+++ b/template/docs/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+Provide a narrative description of what you are trying to accomplish.
+
+### Code to reproduce the issue
+
+```php
+```
+
+### Expected results
+
+### Actual results
+

--- a/template/docs/ISSUE_TEMPLATE.md
+++ b/template/docs/ISSUE_TEMPLATE.md
@@ -1,3 +1,6 @@
+ - [ ] I was not able to find an [open](https://github.com/{org}/{repo}/issues?q=is%3Aopen) or [closed](https://github.com/{org}/{repo}/issues?q=is%3Aclosed) issue matching what I'm seeing.
+ - [ ] This is not a question. (Questions should be asked on [slack](https://zendframework.slack.com/) ([Signup for Slack here](https://zendframework-slack.herokuapp.com/)) or our [forums](https://discourse.zendframework.com/).)
+
 Provide a narrative description of what you are trying to accomplish.
 
 ### Code to reproduce the issue

--- a/template/docs/ISSUE_TEMPLATE.md
+++ b/template/docs/ISSUE_TEMPLATE.md
@@ -5,10 +5,15 @@ Provide a narrative description of what you are trying to accomplish.
 
 ### Code to reproduce the issue
 
+<!-- Please provide the minimum code necessary to recreate the issue -->
+
 ```php
 ```
 
 ### Expected results
 
+<!-- What do you think should have happened? -->
+
 ### Actual results
 
+<!-- What did you actually observe? -->

--- a/template/docs/PULL_REQUEST_TEMPLATE.md
+++ b/template/docs/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,8 @@ Provide a narrative description of what you are trying to accomplish:
   - [ ] Add a `CHANGELOG.md` entry for the new feature.
 
 - [ ] Is this related to quality assurance?
-  - [ ] Detail why the changes are necessary.
+  <!-- Detail why the changes are necessary -->
 
 - [ ] Is this related to documentation?
-  - [ ] Is it a typographical and/or grammatical fix?
-  - [ ] Is it new documentation?
+  <!-- Is it a typographical and/or grammatical fix? -->
+  <!-- Is it new documentation? -->

--- a/template/docs/PULL_REQUEST_TEMPLATE.md
+++ b/template/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+Provide a narrative description of what you are trying to accomplish:
+
+- Are you fixing a bug?
+  - Detail how the bug is invoked currently.
+  - Detail the original, incorrect behavior.
+  - Detail the new, expected behavior.
+
+- Are you creating a new feature?
+  - Why is the new feature needed? What purpose does it serve?
+  - How will users use the new feature?
+
+- Is this related to quality assurance?
+  - Detail why the changes are necessary.
+
+- Is this related to documentation?
+  - Is it a typographical and/or grammatical fix?
+  - Is it new documentation?

--- a/template/docs/PULL_REQUEST_TEMPLATE.md
+++ b/template/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,25 @@
 Provide a narrative description of what you are trying to accomplish:
 
-- Are you fixing a bug?
-  - Detail how the bug is invoked currently.
-  - Detail the original, incorrect behavior.
-  - Detail the new, expected behavior.
+- [ ] Are you fixing a bug?
+  - [ ] Detail how the bug is invoked currently.
+  - [ ] Detail the original, incorrect behavior.
+  - [ ] Detail the new, expected behavior.
+  - [ ] Base your feature on the `master` branch, and submit against that branch.
+  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
+  - [ ] Add a `CHANGELOG.md` entry for the fix.
 
-- Are you creating a new feature?
-  - Why is the new feature needed? What purpose does it serve?
-  - How will users use the new feature?
+- [ ] Are you creating a new feature?
+  - [ ] Why is the new feature needed? What purpose does it serve?
+  - [ ] How will users use the new feature?
+  - [ ] Base your feature on the `develop` branch, and submit against that branch.
+  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
+  - [ ] Add tests for the new feature.
+  - [ ] Add documentation for the new feature.
+  - [ ] Add a `CHANGELOG.md` entry for the new feature.
 
-- Is this related to quality assurance?
-  - Detail why the changes are necessary.
+- [ ] Is this related to quality assurance?
+  - [ ] Detail why the changes are necessary.
 
-- Is this related to documentation?
-  - Is it a typographical and/or grammatical fix?
-  - Is it new documentation?
+- [ ] Is this related to documentation?
+  - [ ] Is it a typographical and/or grammatical fix?
+  - [ ] Is it new documentation?

--- a/template/docs/SUPPORT.md
+++ b/template/docs/SUPPORT.md
@@ -1,0 +1,25 @@
+# Getting Support
+
+Zend Framework offers three support channels:
+
+- For real-time questions, use our
+  [Slack](https://zendframework-slack.herokuapp.com)
+- For detailed questions (e.g., those requiring examples) use our
+  [forums](https://discourse.zendframework.com/c/contributors)
+- To report issues, use this repository's
+  [issue tracker](https://github.com/{org}/{repo}/issues/new)
+
+**DO NOT** use the issue tracker to ask questions; use Slack or the forums for
+that. Questions posed to the issue tracker will be closed.
+
+When reporting an issue, please include the following details:
+
+- A narrative description of what you are trying to accomplish.
+- The minimum code necessary to reproduce the issue.
+- The expected results of exercising that code.
+- The actual results received.
+
+We may ask for additional details: what version of the library you are using,
+and what PHP version was used to reproduce the issue.
+
+You may also submit a failing test case as a pull request.

--- a/template/docs/SUPPORT.md
+++ b/template/docs/SUPPORT.md
@@ -5,7 +5,7 @@ Zend Framework offers three support channels:
 - For real-time questions, use our
   [Slack](https://zendframework-slack.herokuapp.com)
 - For detailed questions (e.g., those requiring examples) use our
-  [forums](https://discourse.zendframework.com/c/contributors)
+  [forums](https://discourse.zendframework.com/c/questions/{category})
 - To report issues, use this repository's
   [issue tracker](https://github.com/{org}/{repo}/issues/new)
 


### PR DESCRIPTION
Adds/proposes the following standard repository templates:

- `LICENSE.md`, containing the license; replace `{year}` with the
  current year during creation.
- `docs/CODE_OF_CONDUCT.md`. Formerly, this was `CONDUCT.md`, but GitHub
  added support for identifying `CODE_OF_CONDUCT.md` several months ago.
- `docs/CONTRIBUTING.md`
- `docs/ISSUE_TEMPLATE.md`. This then acts as an issue template for
  users submitting issues, and helps them determine whether they should
  report or not.
- `docs/PULL_REQUEST_TEMPLATE.md`. This acts as a template for pull
  request submissions, guiding the user to answer questions we need when
  evaluating whether or not to merge.
- `docs/SUPPORT.md`. This new file provides the ability to detail
  locations for different types of support.

GitHub allows a number of documents to be in either the root directory,
a hidden `.github/` directory, or the `docs/` directory. Pushing them
into the `docs/` directory serves two purposes:

- These files no longer litter the root directory.
- Our manual sources are usually under a `book/` subdirectory; if we
  change the top-level subdirectory from `doc/` to `docs/`, then these
  are grouped appropriately, and still segregated.