### PR TITLE
QA Tools config templates

### DIFF
--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -1,0 +1,10 @@
+/docs export-ignore
+/test export-ignore
+/.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/composer.lock export-ignore
+/mkdocs.yml export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml.dist export-ignore

--- a/template/phpcs.xml
+++ b/template/phpcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="Zend Framework coding standard">
+    <rule ref="./vendor/zendframework/zend-coding-standard/ruleset.xml"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+</ruleset>

--- a/template/phpunit.xml.dist
+++ b/template/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="{repository-name}">
+            <directory>./test</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
- `phpcs.xml` template, library should require `zendframework/zend-coding-standard` in composer `require-dev` section (there is PR #15, see https://github.com/zendframework/maintainers/pull/15/files#diff-ea9cb71454501def51e47bec554a6ff1R25),
- `phpunit.xml.dist` - package name should be set in testsuite name attr,
- `.gitattributes`

/cc @froschdesign