### PR TITLE
Update Travis CI template

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -38,7 +38,6 @@ matrix:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update
 
 install:
   - travis_retry composer install $COMPOSER_ARGS

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -33,8 +33,6 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
-  allow_failures:
-    - php: 7.2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi


### PR DESCRIPTION
- removed composer self-update - it is no longer needed as travis do it automatically
- removed allow failures on PHP 7.2