### PR TITLE
Be strict about unintentional test coverage

### DIFF
--- a/template/phpunit.xml.dist
+++ b/template/phpunit.xml.dist
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         forceCoversAnnotation="true"
          colors="true">
     <testsuites>
         <testsuite name="{repo}">


### PR DESCRIPTION
Tests in zend framework are not using `@covers` annotations and create unintentional code coverage which allows some parts of code to remain untested.

I believe forcing covers annotation will make coverage metric more precise and reliable and allow us to further increase code quality.