### PR TITLE
New tool: sync:keywords - synchronize composer.json keywords with github topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This script currently has the following general use commands:
   by default, the current directory is used.
 - `sync:keywords <github-token> -o|--org=<org> -r|--repo=<repo> [--dry-run]`:
   synchronizes composer.json keywords with github topics.
-- `sync-repos <github-token>`: synchronizes zendframework package descriptions.
+- `sync:repos <github-token>`: synchronizes zendframework package descriptions.
 
 and the following commands to help maintain LTS releases:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This script currently has the following general use commands:
 - `create-package <name>`: creates a new package from templates.
 - `rebase-doc-template [<path>]`: rebases all templates in package;
   by default, the current directory is used.
+- `sync:keywords <github-token> -o|--org=<org> -r|--repo=<repo> [--dry-run]`:
+  synchronizes composer.json keywords with github topics.
 - `sync-repos <github-token>`: synchronizes zendframework package descriptions.
 
 and the following commands to help maintain LTS releases:

--- a/bin/zf-maintainer
+++ b/bin/zf-maintainer
@@ -20,7 +20,7 @@ $application->addCommands([
     new CreatePackage('create-package'),
     new RebaseDocTemplates('rebase-doc-templates'),
     new Sync\Keywords('sync:keywords'),
-    new SyncRepos('sync-repos'),
+    new Sync\Repos('sync:repos'),
 
     // lts tools
     (new Lts\Components('lts:components'))->setComponents($components),

--- a/bin/zf-maintainer
+++ b/bin/zf-maintainer
@@ -19,6 +19,7 @@ $application->addCommands([
     new ChangelogBump('changelog-bump'),
     new CreatePackage('create-package'),
     new RebaseDocTemplates('rebase-doc-templates'),
+    new Sync\Keywords('sync:keywords'),
     new SyncRepos('sync-repos'),
 
     // lts tools

--- a/src/Sync/Keywords.php
+++ b/src/Sync/Keywords.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/maintainers for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZF\Maintainer\Sync;
+
+use Github\Client;
+use Github\HttpClient\Message\ResponseMediator;
+use InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Keywords extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setDescription('Synchronize composer.json keywords with GitHub topics')
+            ->setHelp(
+                'Update all GitHub topics to match keywords provided in composer.json file of the repository.'
+            )
+            ->addArgument(
+                'token',
+                InputArgument::REQUIRED,
+                'GitHub access token'
+            )
+            ->addOption(
+                'org',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'Organization to update GitHub topics'
+            )
+            ->addOption(
+                'repo',
+                'r',
+                InputOption::VALUE_REQUIRED,
+                'Repository pattern to synchronize GitHub topics;'
+                . ' * can be used to match any repository name or part of the name'
+            )
+            ->addOption('dry-run', null, null, 'Dry run to see what is going to be done.');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+
+        $org = $input->getOption('org');
+        if (! preg_match('/^[a-z0-9-]+$/i', $org)) {
+            throw new InvalidArgumentException(
+                'Invalid organization name, can contain only letter, numbers and dash'
+            );
+        }
+
+        $repo = $input->getOption('repo');
+        if (! preg_match('/^[a-z0-9*-]+$/i', $repo)) {
+            throw new InvalidArgumentException(
+                'Invalid repository pattern, can contain only letters, numbers, dash and *'
+            );
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $token = $input->getArgument('token');
+        $org = $input->getOption('org');
+        $repo = $input->getOption('repo');
+        $dryRun = $input->getOption('dry-run');
+
+        $client = new Client();
+        $client->authenticate($token, null, $client::AUTH_URL_TOKEN);
+        $httpClient = $client->getHttpClient();
+
+        $repos = $this->getRepos($client, $org, $repo);
+
+        $output->writeln(sprintf('Found <info>%d</info> matching repositories:', count($repos)));
+
+        foreach ($repos as $name => $repo) {
+            $output->write(sprintf('%s: ', $name));
+            if (! $repo['keywords']) {
+                $output->writeln('<error>ERROR: Missing keywords in composer.json</error>');
+                continue;
+            }
+
+            $toRemove = array_diff($repo['topics'], $repo['keywords']);
+            foreach ($toRemove as $tag) {
+                $output->write('<error>' . $tag . '</error> ');
+            }
+
+            $toAdd = array_diff($repo['keywords'], $repo['topics']);
+            foreach ($toAdd as $tag) {
+                $output->write('<question>' . $tag . '</question> ');
+            }
+
+            if (! $toRemove && ! $toAdd) {
+                $output->write('<info>OK</info>');
+            }
+
+            $output->writeln('');
+
+            if (! $dryRun) {
+                $httpClient->put(
+                    sprintf('/repos/%s/%s/topics', $org, $name),
+                    ['Accept' => 'application/vnd.github.mercy-preview+json'],
+                    json_encode(['names' => $repo['keywords']])
+                );
+            }
+        }
+    }
+
+    private function getRepos(Client $client, $org, $repo)
+    {
+        $httpClient = $client->getHttpClient();
+
+        $repos = [];
+
+        $repoPreg = '/^' . str_replace('\*', '.*', preg_quote($repo, '\\')) . '$/';
+        $repoSearchPhrase = str_replace('*', '', $repo);
+        $page = 0;
+        $processed = 0;
+
+        do {
+            $response = ResponseMediator::getContent(
+                $httpClient->get('/search/repositories?' . http_build_query([
+                    'q' => sprintf('%s in:name user:%s fork:true', $repoSearchPhrase, $org),
+                    'order' => 'asc',
+                    'page' => ++$page,
+                ]), ['Accept' => 'application/vnd.github.mercy-preview+json'])
+            );
+
+            $totalCount = $response['total_count'];
+            $processed += count($response['items']);
+
+            foreach ($response['items'] as $item) {
+                if (! preg_match($repoPreg, $item['name'])) {
+                    continue;
+                }
+
+                $url = sprintf(
+                    'https://raw.githubusercontent.com/%s/master/composer.json',
+                    $item['full_name']
+                );
+                $json = json_decode(file_get_contents($url), true);
+
+                $repos[$item['name']] = [
+                    'topics' => $item['topics'],
+                    'keywords' => isset($json['keywords']) ? $json['keywords'] : [],
+                ];
+            }
+        } while ($processed < $totalCount);
+
+        ksort($repos);
+
+        return $repos;
+    }
+}

--- a/src/Sync/Keywords.php
+++ b/src/Sync/Keywords.php
@@ -24,6 +24,11 @@ class Keywords extends Command
             ->setDescription('Synchronize composer.json keywords with GitHub topics')
             ->setHelp(
                 'Update all GitHub topics to match keywords provided in composer.json file of the repository.'
+                . PHP_EOL . PHP_EOL
+                . 'Please run script with --dry-run flag first to determine differences between GitHub topics'
+                . ' and repository composer.json keywords. For each repository output contains the color-coded'
+                . ' keyword list. Keywords marked on red are going to be removed from GitHub tokens; marked on'
+                . ' cyan - added (or updated).'
             )
             ->addArgument(
                 'token',
@@ -43,7 +48,13 @@ class Keywords extends Command
                 'Repository pattern to synchronize GitHub topics;'
                 . ' * can be used to match any repository name or part of the name'
             )
-            ->addOption('dry-run', null, null, 'Dry run to see what is going to be done.');
+            ->addOption(
+                'dry-run',
+                null,
+                null,
+                'Outputs the differences between GitHub topics and composer.json keywords.'
+                . ' It should be used to determine if the GitHub topics contain keywords not in the composer.json.'
+            );
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)

--- a/src/Sync/Repos.php
+++ b/src/Sync/Repos.php
@@ -5,7 +5,7 @@
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 
-namespace ZF\Maintainer;
+namespace ZF\Maintainer\Sync;
 
 use Github\Client;
 use Symfony\Component\Console\Command\Command;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SyncRepos extends Command
+class Repos extends Command
 {
     protected function configure()
     {


### PR DESCRIPTION
```console
$ zf-maintainer sync:keywords <github-token> -o|--org=<org> -r|--repo=<repo-pattern> [--dry-run]
```
Replaces all github topics with keywords from composer.json file (`master` branch) for repositories matching provided pattern `<repo-pattern>` in provided organization `<org>`.
`<repo-pattern>` can be alphanumeric string with dashes and `*` to match any part of the repository name.

Here we have `--dry-run` result for following command:
```console
$ bin/zf-maintainer sync:keywords <TOKEN> --org=zendframework --repo=zend-expressive* --dry-run
```

![screenshot from 2017-11-24 14-33-03](https://user-images.githubusercontent.com/7423207/33214758-21289bb8-d125-11e7-9fae-e618a4cdd5f4.png)

On red we have marked topics to remove, cyan - keywords to add.
In case we don't have any keywords in the composer.json there is an error message next to the repository name. Repositories are sorted by name, asc.

Resolves #35 
/cc @Xerkus @froschdesign
