### PR TITLE
Updated command to upload coverage in Travis CI config

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -49,7 +49,7 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi
 
 notifications:
   email: false


### PR DESCRIPTION
- Occasionally upload fails, so using travis_retry gives us a couple retries.
- Occasionally, the executable bit is not set on vendor binaries; this ensures the command will still run.

- per @weierophinney

https://github.com/zendframework/zend-diactoros/pull/288#discussion_r161881452