### PR TITLE
Update for readme template (removes build command and adds support section)

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -15,10 +15,4 @@ $ composer require {org}/{repo}
 
 ## Documentation
 
-Documentation is [in the doc tree](docs/book/), and can be compiled using [mkdocs](http://www.mkdocs.org):
-
-```bash
-$ mkdocs build
-```
-
-You may also [browse the documentation online](https://docs.zendframework.com/{repo}/).
+Browse the documentation online at https://docs.zendframework.com/{repo}/

--- a/template/README.md
+++ b/template/README.md
@@ -16,3 +16,9 @@ $ composer require {org}/{repo}
 ## Documentation
 
 Browse the documentation online at https://docs.zendframework.com/{repo}/
+
+## Support
+
+* [Issues](https://github.com/zendframework/{repo}/issues/)
+* [Chat](https://zendframework-slack.herokuapp.com/)
+* [Forum](https://discourse.zendframework.com/)


### PR DESCRIPTION
Why should creating the documentation be interesting for the end user? The user wants to read the documentation and not create it himself.

Preview:

---

# {repo}

[![Build Status](https://secure.travis-ci.org/{org}/{repo}.svg?branch=master)](https://secure.travis-ci.org/{org}/{repo})
[![Coverage Status](https://coveralls.io/repos/github/{org}/{repo}/badge.svg?branch=master)](https://coveralls.io/github/{org}/{repo}?branch=master)

This library provides ...

## Installation

Run the following to install this library:

```bash
$ composer require {org}/{repo}
```

## Documentation

Browse the documentation online at https://docs.zendframework.com/{repo}/

## Support

* [Issues](https://github.com/zendframework/{repo}/issues/)
* [Chat](https://zendframework-slack.herokuapp.com/)
* [Forum](https://discourse.zendframework.com/)