### PR TITLE
Added Copyright template - COPYRIGHT.md

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright (c) 2015-2018, Zend Technologies USA, Inc.
+Copyright (c) 2005-2018, Zend Technologies USA, Inc. All rights reserved.

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2015-2018, Zend Technologies USA, Inc.

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright (c) 2005-2018, Zend Technologies USA, Inc. All rights reserved.
+Copyright (c) 2005-2018, Zend Technologies USA, Inc. All rights reserved. (https://www.zend.com)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017, Zend Technologies USA, Inc.
+Copyright (c) 2015-2018, Zend Technologies USA, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2018, Zend Technologies USA, Inc.
+Copyright (c) 2005-2018, Zend Technologies USA, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/bin/zf-maintainer
+++ b/bin/zf-maintainer
@@ -2,7 +2,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/bin/zf-maintainer
+++ b/bin/zf-maintainer
@@ -2,7 +2,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ChangelogBump.php
+++ b/src/ChangelogBump.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ChangelogBump.php
+++ b/src/ChangelogBump.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/CreatePackage.php
+++ b/src/CreatePackage.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/CreatePackage.php
+++ b/src/CreatePackage.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Components.php
+++ b/src/Lts/Components.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Components.php
+++ b/src/Lts/Components.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Patch.php
+++ b/src/Lts/Patch.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Patch.php
+++ b/src/Lts/Patch.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Release.php
+++ b/src/Lts/Release.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Release.php
+++ b/src/Lts/Release.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Stage.php
+++ b/src/Lts/Stage.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Lts/Stage.php
+++ b/src/Lts/Stage.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/RebaseDocTemplates.php
+++ b/src/RebaseDocTemplates.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/RebaseDocTemplates.php
+++ b/src/RebaseDocTemplates.php
@@ -36,6 +36,7 @@ class RebaseDocTemplates extends Command
                 . '  - updates .gitattributes and .gitignore definitions' . PHP_EOL
                 . '  - creates Travis CI configuration if does not exist' . PHP_EOL
                 . '  - updates LICENSE.md year range; creates file if it does not exist' . PHP_EOL
+                . '  - updates COPYRIGHT.md year range; creates file if it does not exist' . PHP_EOL
                 . '  - updates documentation configuration (copyright year and docs/ dir)' . PHP_EOL
                 . '  - updates composer.json skeleton:' . PHP_EOL
                 . '    - checks and fixes repository description (only for zendframework org)' . PHP_EOL
@@ -109,6 +110,7 @@ class RebaseDocTemplates extends Command
         if ($hasDocs) {
             $this->updateMkDocs($yearReplacement);
         }
+        $this->updateCopyright($yearReplacement);
         $this->updateReadme($replacement);
         $this->updateDocsFiles();
 
@@ -389,6 +391,13 @@ class RebaseDocTemplates extends Command
         file_put_contents('LICENSE.md', $content);
 
         return $yearReplacement;
+    }
+
+    private function updateCopyright($yearReplacement)
+    {
+        $content = file_get_contents(__DIR__ . '/../template/COPYRIGHT.md');
+        $content = str_replace('{year}', $yearReplacement, $content);
+        file_put_contents('COPYRIGHT.md', $content);
     }
 
     private function updateMkDocs($yearReplacement)

--- a/src/RebaseDocTemplates.php
+++ b/src/RebaseDocTemplates.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Sync/Keywords.php
+++ b/src/Sync/Keywords.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Sync/Keywords.php
+++ b/src/Sync/Keywords.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/maintainers for the canonical source repository
- * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/zendframework/maintainers/blob/master/COPYRIGHT.md
  * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
  */
 

--- a/template/COPYRIGHT.md
+++ b/template/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright (c) {year}, Zend Technologies USA, Inc.
+Copyright (c) {year}, Zend Technologies USA, Inc. All rights reserved.

--- a/template/COPYRIGHT.md
+++ b/template/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright (c) {year}, Zend Technologies USA, Inc. All rights reserved.
+Copyright (c) {year}, Zend Technologies USA, Inc. All rights reserved. (https://www.zend.com)

--- a/template/COPYRIGHT.md
+++ b/template/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) {year}, Zend Technologies USA, Inc.

--- a/template/src/ConfigProvider.php
+++ b/template/src/ConfigProvider.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/{org}/{repo} for the canonical source repository
- * @copyright https://github.com/{org}/{repo}/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/{org}/{repo}/blob/master/COPYRIGHT.md
  * @license   https://github.com/{org}/{repo}/blob/master/LICENSE.md New BSD License
  */
 

--- a/template/src/ConfigProvider.php
+++ b/template/src/ConfigProvider.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/{org}/{repo} for the canonical source repository
- * @copyright Copyright (c) {year} Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/{org}/{repo}/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/{org}/{repo}/blob/master/LICENSE.md New BSD License
  */
 

--- a/template/test/ConfigProviderTest.php
+++ b/template/test/ConfigProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/{org}/{repo} for the canonical source repository
- * @copyright https://github.com/{org}/{repo}/blob/master/COPYRIGHT.md Copyright
+ * @copyright https://github.com/{org}/{repo}/blob/master/COPYRIGHT.md
  * @license   https://github.com/{org}/{repo}/blob/master/LICENSE.md New BSD License
  */
 

--- a/template/test/ConfigProviderTest.php
+++ b/template/test/ConfigProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/{org}/{repo} for the canonical source repository
- * @copyright Copyright (c) {year} Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright https://github.com/{org}/{repo}/blob/master/COPYRIGHT.md Copyright
  * @license   https://github.com/{org}/{repo}/blob/master/LICENSE.md New BSD License
  */
 


### PR DESCRIPTION
As it was agreed a long time ago .... we need COPYRIGHT.md file and then in headers we are going to have reference to that file.

As I'm updating zend-coding-standard we need template in one common place.