### PR TITLE
Use chat instead of slack in templates

### DIFF
--- a/LTS-WORKFLOW.md
+++ b/LTS-WORKFLOW.md
@@ -162,5 +162,5 @@ Now that the tag is made, the Zend team will need to build and release distribut
 such, please coordinate with them whenever you tag, so that they can do so as soon as possible after
 a tag is created.
 
-If you cannot find one of them in the [Slack](https://zendframework-slack.herokuapp.com),
+If you cannot find one of them in the [Chat](https://zendframework-slack.herokuapp.com),
 please send an email to zf-devteam@zend.com.

--- a/template/composer.json
+++ b/template/composer.json
@@ -13,7 +13,7 @@
         "issues": "https://github.com/{org}/{repo}/issues",
         "source": "https://github.com/{org}/{repo}",
         "rss": "https://github.com/{org}/{repo}/releases.atom",
-        "slack": "https://zendframework-slack.herokuapp.com",
+        "chat": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/{category}"
     },
     "require": {

--- a/template/docs/CONTRIBUTING.md
+++ b/template/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@ read/subscribe to the following resources:
 
  - [Coding Standards](https://github.com/zendframework/zend-coding-standard)
  - [Forums](https://discourse.zendframework.com/c/contributors)
- - [Slack](https://zendframework-slack.herokuapp.com)
+ - [Chat](https://zendframework-slack.herokuapp.com)
  - [Code of Conduct](CODE_OF_CONDUCT.md)
 
 If you are working on new features or refactoring

--- a/template/docs/ISSUE_TEMPLATE.md
+++ b/template/docs/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
  - [ ] I was not able to find an [open](https://github.com/{org}/{repo}/issues?q=is%3Aopen) or [closed](https://github.com/{org}/{repo}/issues?q=is%3Aclosed) issue matching what I'm seeing.
- - [ ] This is not a question. (Questions should be asked on [slack](https://zendframework.slack.com/) ([Signup for Slack here](https://zendframework-slack.herokuapp.com/)) or our [forums](https://discourse.zendframework.com/).)
+ - [ ] This is not a question. (Questions should be asked on [chat](https://zendframework.slack.com/) ([Signup here](https://zendframework-slack.herokuapp.com/)) or our [forums](https://discourse.zendframework.com/).)
 
 Provide a narrative description of what you are trying to accomplish.
 

--- a/template/docs/SUPPORT.md
+++ b/template/docs/SUPPORT.md
@@ -3,13 +3,13 @@
 Zend Framework offers three support channels:
 
 - For real-time questions, use our
-  [Slack](https://zendframework-slack.herokuapp.com)
+  [chat](https://zendframework-slack.herokuapp.com)
 - For detailed questions (e.g., those requiring examples) use our
   [forums](https://discourse.zendframework.com/c/questions/{category})
 - To report issues, use this repository's
   [issue tracker](https://github.com/{org}/{repo}/issues/new)
 
-**DO NOT** use the issue tracker to ask questions; use Slack or the forums for
+**DO NOT** use the issue tracker to ask questions; use chat or the forums for
 that. Questions posed to the issue tracker will be closed.
 
 When reporting an issue, please include the following details:


### PR DESCRIPTION
As we changed slack to chat in PR https://github.com/zendframework/maintainers/pull/40 we should update also templates to use Chat instead of Slack.

/cc @weierophinney @froschdesign 