### PR TITLE
phploc tool

### DIFF
--- a/bin/zf-maintainer
+++ b/bin/zf-maintainer
@@ -18,6 +18,7 @@ $application = new Application('zf-maintainer');
 $application->addCommands([
     new ChangelogBump('changelog-bump'),
     new CreatePackage('create-package'),
+    new PhplocCommand('phploc'),
     new RebaseDocTemplates('rebase-doc-templates'),
     new Sync\Keywords('sync:keywords'),
     new Sync\Repos('sync:repos'),

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "488a8554f885d0413453cc74f7300193",
@@ -60,16 +60,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.3.0",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
-                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
                 "shasum": ""
             },
             "require": {
@@ -79,7 +79,7 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0 || ^5.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
                 "psr/log": "^1.0"
             },
             "suggest": {
@@ -88,7 +88,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.2-dev"
+                    "dev-master": "6.3-dev"
                 }
             },
             "autoload": {
@@ -121,7 +121,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-06-22T18:50:49+00:00"
+            "time": "2018-04-22T15:46:56+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -241,22 +241,22 @@
         },
         {
             "name": "knplabs/github-api",
-            "version": "2.6.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/php-github-api.git",
-                "reference": "cacf6f38bf9e6c5242e2b6dc26a67c4791bc7751"
+                "reference": "31abea216314657904f8fd7a6a5516d47199399b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/cacf6f38bf9e6c5242e2b6dc26a67c4791bc7751",
-                "reference": "cacf6f38bf9e6c5242e2b6dc26a67c4791bc7751",
+                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/31abea216314657904f8fd7a6a5516d47199399b",
+                "reference": "31abea216314657904f8fd7a6a5516d47199399b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "php-http/cache-plugin": "^1.4",
-                "php-http/client-common": "^1.3",
+                "php-http/client-common": "^1.6",
                 "php-http/client-implementation": "^1.0",
                 "php-http/discovery": "^1.0",
                 "php-http/httplug": "^1.1",
@@ -268,13 +268,13 @@
                 "guzzlehttp/psr7": "^1.2",
                 "php-http/guzzle6-adapter": "^1.0",
                 "php-http/mock-client": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.5",
+                "phpunit/phpunit": "^5.5 || ^6.0",
                 "sllh/php-cs-fixer-styleci-bridge": "^1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6.x-dev"
+                    "dev-master": "2.9.x-dev"
                 }
             },
             "autoload": {
@@ -305,7 +305,7 @@
                 "gist",
                 "github"
             ],
-            "time": "2017-09-30T20:00:06+00:00"
+            "time": "2018-07-23T07:41:29+00:00"
         },
         {
             "name": "php-http/cache-plugin",
@@ -426,16 +426,16 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "7b50ab4d6c9fdaa1ed53ae310c955900af6e3372"
+                "reference": "9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/7b50ab4d6c9fdaa1ed53ae310c955900af6e3372",
-                "reference": "7b50ab4d6c9fdaa1ed53ae310c955900af6e3372",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33",
+                "reference": "9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33",
                 "shasum": ""
             },
             "require": {
@@ -484,7 +484,7 @@
                 "message",
                 "psr7"
             ],
-            "time": "2017-08-03T10:12:53+00:00"
+            "time": "2018-02-06T10:55:24+00:00"
         },
         {
             "name": "php-http/guzzle6-adapter",
@@ -604,21 +604,21 @@
         },
         {
             "name": "php-http/message",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/message.git",
-                "reference": "2edd63bae5f52f79363c5f18904b05ce3a4b7253"
+                "reference": "741f2266a202d59c4ed75436671e1b8e6f475ea3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message/zipball/2edd63bae5f52f79363c5f18904b05ce3a4b7253",
-                "reference": "2edd63bae5f52f79363c5f18904b05ce3a4b7253",
+                "url": "https://api.github.com/repos/php-http/message/zipball/741f2266a202d59c4ed75436671e1b8e6f475ea3",
+                "reference": "741f2266a202d59c4ed75436671e1b8e6f475ea3",
                 "shasum": ""
             },
             "require": {
-                "clue/stream-filter": "^1.3",
-                "php": ">=5.4",
+                "clue/stream-filter": "^1.4",
+                "php": "^5.4 || ^7.0",
                 "php-http/message-factory": "^1.0.2",
                 "psr/http-message": "^1.0"
             },
@@ -672,7 +672,7 @@
                 "message",
                 "psr-7"
             ],
-            "time": "2017-07-05T06:40:53+00:00"
+            "time": "2018-08-15T06:37:30+00:00"
         },
         {
             "name": "php-http/message-factory",
@@ -872,16 +872,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.0.0",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5cd0dd461dfc72f59c8405cac32d31e82c7348e8"
+                "reference": "ca80b8ced97cf07390078b29773dc384c39eee1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5cd0dd461dfc72f59c8405cac32d31e82c7348e8",
-                "reference": "5cd0dd461dfc72f59c8405cac32d31e82c7348e8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ca80b8ced97cf07390078b29773dc384c39eee1f",
+                "reference": "ca80b8ced97cf07390078b29773dc384c39eee1f",
                 "shasum": ""
             },
             "require": {
@@ -901,7 +901,7 @@
                 "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
-                "psr/log": "For using the console logger",
+                "psr/log-implementation": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -909,7 +909,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -936,20 +936,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-29T13:42:03+00:00"
+            "time": "2018-07-26T11:24:31+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.0.0",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "ef617a2867c7d889d4ecee3c29595698d87474a4"
+                "reference": "1913f1962477cdbb13df951f8147d5da1fe2412c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ef617a2867c7d889d4ecee3c29595698d87474a4",
-                "reference": "ef617a2867c7d889d4ecee3c29595698d87474a4",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/1913f1962477cdbb13df951f8147d5da1fe2412c",
+                "reference": "1913f1962477cdbb13df951f8147d5da1fe2412c",
                 "shasum": ""
             },
             "require": {
@@ -958,7 +958,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -990,20 +990,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2017-11-07T14:45:01+00:00"
+            "time": "2018-07-26T08:55:25+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.6.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
-                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
                 "shasum": ""
             },
             "require": {
@@ -1015,7 +1015,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -1049,7 +1049,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11T12:05:26+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/Phploc/GitRepo.php
+++ b/src/Phploc/GitRepo.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/maintainers for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZF\Maintainer\Phploc;
+
+use RuntimeException;
+
+use function glob;
+use function is_dir;
+use function rmdir;
+use function unlink;
+
+use const GLOB_BRACE;
+use const GLOB_MARK;
+
+class GitRepo
+{
+    /**
+     * Name or path to git binary.
+     *
+     * @var string
+     */
+    private $git;
+
+    /**
+     * Path to working directory under which to clone.
+     *
+     * @var string
+     */
+    private $workdir;
+
+    public function __construct(string $git, string $workdir)
+    {
+        $this->git = $git;
+        $this->workdir = $workdir;
+    }
+
+    /**
+     * @return string The path to the created repository
+     * @throws RuntimeException if unable to clone the repository
+     */
+    public function clone(string $repository) : string
+    {
+        [$org, $repo] = explode('/', $repository, 2);
+        $path = sprintf('%s/%s', $this->workdir, $repo);
+        $command = sprintf(
+            '%s clone git://github.com/%s.git %s',
+            $this->git,
+            $repository,
+            $path
+        );
+        exec($command, $output, $status);
+
+        if (0 !== $status) {
+            throw new RuntimeException(sprintf(
+                'Unable to clone %s to %s: %s',
+                $repository,
+                $path,
+                implode(PHP_EOL, $output)
+            ));
+        }
+
+        return $path;
+    }
+
+    public function cleanup(string $path) : void
+    {
+        foreach (glob($path . '/{,.}[!.,!..]*', GLOB_MARK|GLOB_BRACE) as $file) {
+            is_dir($file) ? $this->cleanup($file) : unlink($file);
+        }
+        rmdir($path);
+    }
+}

--- a/src/Phploc/Phploc.php
+++ b/src/Phploc/Phploc.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/maintainers for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZF\Maintainer\Phploc;
+
+use RuntimeException;
+
+class Phploc
+{
+    /**
+     * Path to phploc binary
+     *
+     * @var string
+     */
+    private $phploc;
+
+    /**
+     * Path to grep binary
+     *
+     * @var string
+     */
+    private $grep;
+
+    /**
+     * Regexp for identifying count within phploc output.
+     *
+     * Scans only for values in the NCLOC line.
+     *
+     * @var string
+     */
+    private $regexp = '/\(NCLOC\)\s+(?P<count>\d+)\s+/';
+
+    public function __construct(string $phploc, string $grep)
+    {
+        $this->phploc = $phploc;
+        $this->grep = $grep;
+    }
+
+    /**
+     * @throws RuntimeException if phploc + grep has a non-zero exit status
+     * @throws RuntimeException if unable to find the NCLOC count in the returned output
+     */
+    public function count(string $path) : int
+    {
+        $command = sprintf(
+            '%s %s | %s NCLOC',
+            $this->phploc,
+            $path,
+            $this->grep
+        );
+
+        exec($command, $output, $status);
+
+        $output = implode(PHP_EOL, $output);
+        if ($status !== 0) {
+            throw new RuntimeException(sprintf(
+                'Unable to calculate phploc for path %s: %s',
+                $path,
+                implode(PHP_EOL, $output)
+            ));
+        }
+
+        if (! preg_match($this->regexp, $output, $matches)) {
+            throw new RuntimeException(sprintf(
+                'Unable to identify NCLOC value for repo %s; received %s',
+                $path,
+                $output
+            ));
+        }
+
+        return (int) $matches['count'];
+    }
+}

--- a/src/Phploc/RepositoryFetcher.php
+++ b/src/Phploc/RepositoryFetcher.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/maintainers for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZF\Maintainer\Phploc;
+
+use Closure;
+use Github\Client;
+use RuntimeException;
+
+class RepositoryFetcher
+{
+    /**
+     * @todo Add zf1, zf1-extras to this list 2018-01-01, as Zend Server support
+     *     for ZF1 ends the day previous.
+     * @var string[]
+     */
+    private const REPO_BLOCKLIST = [
+        'zendframework/zendframework', // metapackage
+        'zendframework/zendframework.github.io',
+        'zendframework/zend-coding-standard',
+        'zendframework/zend-mvc-form', // metapackage
+        'zendframework/zend-mvc-plugins', // metapackage
+        'zendframework/zf2-documentation',
+        'zendframework/zf2-tutorial',
+        'zendframework/zf3-web',
+        'zendframework/zfbot',
+        'zendframework/zf-composer-repository',
+        'zendframework/zf-mkdoc-theme',
+        'zendframework/zf-web',
+        'zfcampus/zendcon-design-patterns',
+        'zfcampus/zf-angular',
+        'zfcampus/zf-apigility-example',
+        'zfcampus/zf-apigility-welcome',
+    ];
+
+    /**
+     * @var string[]
+     */
+    private const REPO_ACCEPTLIST = [
+        'zendframework/ZendService_Amazon',
+        'zendframework/ZendService_Apple_Apns',
+        'zendframework/ZendService_Google_Gcm',
+        'zendframework/ZendService_ReCaptcha',
+        'zendframework/ZendService_Twitter',
+        'zendframework/ZendSkeletonApplication',
+        'zendframework/ZendXml',
+    ];
+
+    /**
+     * Arbitrary start cursor for paginated results.
+     *
+     * @var string
+     */
+    private const GRAPHQL_CURSOR_START = 'Y3Vyc29yOjEwMA==';
+
+    /**
+     * Organizations we will query.
+     *
+     * @var string[]
+     */
+    private const GRAPHQL_ORGANIZATIONS = [
+        'zendframework',
+        'zfcampus',
+    ];
+
+    /**
+     * Query for fetching all repositories from GitHub.
+     *
+     * The two ids provided are the GitHub unique identifiers for the zendframework
+     * and zfcampus organizations, respectively.
+     *
+     * The "after" string is for providing an initial cursoer so that we can page
+     * through results in order to retrieve all information.
+     *
+     * @var string
+     */
+    private const GRAPHQL_QUERY = <<< 'EOT'
+query tagsByOrganization(
+  $organization: String!
+  $cursor: String!
+) {
+  organization(login: $organization) {
+    repositories(first: 100, after: $cursor) {
+      pageInfo {
+        startCursor
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        nameWithOwner
+      }
+    }
+  }
+}
+EOT;
+
+    /**
+     * @var callable[]
+     */
+    private $criteria;
+
+    public function __construct()
+    {
+        $this->criteria = [
+            Closure::fromCallable([$this, 'filterBlockList']),
+            Closure::fromCallable([$this, 'filterAcceptList']),
+        ];
+    }
+
+    public function execute(Client $client) : iterable
+    {
+        $data = [];
+
+        foreach (self::GRAPHQL_ORGANIZATIONS as $organization) {
+            $cursor = self::GRAPHQL_CURSOR_START;
+
+            do {
+                $results = $client->api('graphql')->execute(self::GRAPHQL_QUERY, [
+                    'organization' => $organization,
+                    'cursor' => $cursor,
+                ]);
+
+                if (isset($results['errors'])) {
+                    throw new RuntimeException(sprintf(
+                        'Error fetching repositories: %s',
+                        $results['errors']['message']
+                    ));
+                }
+
+                $data = array_merge($data, $results['data']['organization']['repositories']['nodes']);
+
+                $cursor = $this->getNextCursorFromResults($results);
+            } while ($cursor);
+        }
+
+        return $this->processData($data);
+    }
+
+    private function getNextCursorFromResults(array $results) : ?string
+    {
+        // @codingStandardsIgnoreStart
+        return isset($results['data']['organization']['repositories']['pageInfo']['hasNextPage'])
+            ? $results['data']['organization']['repositories']['pageInfo']['endCursor']
+            : null;
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @return string[]
+     */
+    private function processData(array $data) : iterable
+    {
+        $repos = array_filter(array_column($data, 'nameWithOwner'), function ($repository) {
+            foreach ($this->criteria as $criteria) {
+                if (! $criteria($repository)) {
+                    return false;
+                }
+            }
+            return true;
+        });
+        natsort($repos);
+        return $repos;
+    }
+
+    private function filterBlockList(string $name) : bool
+    {
+        return ! in_array($name, self::REPO_BLOCKLIST, true);
+    }
+
+    private function filterAcceptList(string $name) : bool
+    {
+        [$org, $repo] = explode('/', $name, 2);
+        return in_array($name, self::REPO_ACCEPTLIST, true)
+            || 'z' === $repo[0];
+    }
+}

--- a/src/PhplocCommand.php
+++ b/src/PhplocCommand.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/maintainers for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/maintainers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZF\Maintainer;
+
+use Github\Client;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class PhplocCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setDescription('Calculate lines of code for the entire project');
+        $this->setHelp(
+            'Retrieves a list of all repositories under the zendframework and zfcampus'
+            . ' organizations, performs a local checkout of the repository, and then runs'
+            . ' phploc over each, reporting the non-comment lines of code for each. When'
+            . ' complete, it also reports a sum total of all repositories.'
+        );
+        $this->addArgument(
+            'token',
+            InputArgument::REQUIRED,
+            'GitHub OAuth2 token to use for retrieving the repository list.'
+        );
+        $this->addOption(
+            'workdir',
+            'w',
+            InputOption::VALUE_REQUIRED,
+            'Directory into which to perform git clones of each repository;'
+                . ' defaults to current working directory.',
+            getcwd()
+        );
+        $this->addOption(
+            'phplocbin',
+            'p',
+            InputOption::VALUE_REQUIRED,
+            'Name or path to phploc binary to use when performing phploc calculations.',
+            'phploc'
+        );
+        $this->addOption(
+            'gitbin',
+            'g',
+            InputOption::VALUE_REQUIRED,
+            'Name or path to git binary to use to perform git cloning operations.',
+            'git'
+        );
+        $this->addOption(
+            'grepbin',
+            'r',
+            InputOption::VALUE_REQUIRED,
+            'Name or path to grep binary to use when filtering phploc output.',
+            'grep'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $token = $input->getArgument('token');
+        $workdir = $input->getOption('workdir');
+        $phploc = $input->getOption('phplocbin');
+        $git = $input->getOption('gitbin');
+        $grep = $input->getOption('grepbin');
+
+        $output->writeln('<info>Fetching repository list...</info>');
+
+        $client = new Client();
+        $client->authenticate($token, Client::AUTH_HTTP_TOKEN);
+
+        $gitRepo = new Phploc\GitRepo($git, $workdir);
+        $counter = new Phploc\Phploc($phploc, $grep);
+
+        $errors = 0;
+        $counts = [];
+        $total = 0;
+
+        foreach ((new Phploc\RepositoryFetcher())->execute($client) as $repo) {
+            $output->writeln(sprintf('<comment>%s</comment>', $repo));
+            $output->write('  <info>Cloning repository...</info>');
+            try {
+                $path = $gitRepo->clone($repo);
+            } catch (RuntimeException $e) {
+                $output->writeln('<error>FAILED</error>');
+                $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+                $errors +=1;
+                continue;
+            }
+            $output->writeln(sprintf('Done! Cloned to %s', $path));
+
+            $output->write('  <info>Performing count...</info>');
+            try {
+                $count = $counter->count($path);
+                $counts[$repo] = $count;
+                $total += $count;
+                $output->writeln(sprintf(' %d', $count));
+            } catch (RuntimeException $e) {
+                $output->writeln('<error>FAILED</error>');
+                $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+                $errors +=1;
+            }
+
+            $output->write('  <info>Deleting repository...</info>');
+            $gitRepo->cleanup($path);
+            $output->writeln(sprintf('Done!', $path));
+        }
+
+        $this->emitTable($input, $output, $total, $counts);
+
+        if ($errors > 0) {
+            $output->writeln('');
+            $output->writeln(
+                '<error>FINISHED, but one or more errors were reported. Check your output for details.</error>'
+            );
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private function emitTable(InputInterface $input, OutputInterface $output, int $total, array $repos) : void
+    {
+        $table = [];
+
+        foreach ($repos as $repo => $count) {
+            $table[] = [$repo, $count];
+        }
+
+        $io = new SymfonyStyle($input, $output);
+        $io->newLine();
+        $io->section('PHPLOC Results');
+        $io->table(
+            ['Repository', 'Count'],
+            $table
+        );
+        $io->newLine();
+        $output->writeln(sprintf('<info>Total LOC:</info> %d', $total));
+    }
+}


### PR DESCRIPTION
This patch adds a new command to the `zf-maintainer` tool, `phploc`. When executed, it will fetch a list of all repositories from the zendframework and zfcampus organizations, and, for each repository:

- clone it locally
- run phploc over the repository
- remove the clone

Once done, it presents a table with each repository and the NCLOC (non-comment lines of code) associated with it, with the cumulative total tallied at the end.