### PR TITLE
Added PHP 7.3 to .travis.yml template

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 
 cache:
@@ -31,6 +29,15 @@ matrix:
       env:
         - DEPS=locked
     - php: 7.2
+      env:
+        - DEPS=latest
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=locked
+    - php: 7.3
       env:
         - DEPS=latest
 


### PR DESCRIPTION
As PHP 7.3 is now released we should run builds on PHP 7.3.
Removed `sudo: false` as it is deprecated and no longer allowed.